### PR TITLE
Read the neurostore reference from the studyset release API

### DIFF
--- a/compose_runner/run.py
+++ b/compose_runner/run.py
@@ -5,6 +5,8 @@ import hashlib
 import json
 import io
 import pickle
+import tarfile
+import tempfile
 from copy import deepcopy
 from datetime import date, datetime
 from importlib import import_module
@@ -27,7 +29,7 @@ from nimare.correct import FDRCorrector
 from nimare.workflows import CBMAWorkflow, IBMAWorkflow, PairwiseCBMAWorkflow
 from nimare.meta.cbma.base import CBMAEstimator, PairwiseCBMAEstimator
 from nimare.meta.ibma import IBMAEstimator
-from nimare.nimads import Studyset
+from nimare.nimads import Studyset, from_parquet
 from nimare.meta.cbma import ALE, ALESubtraction, SCALE
 
 from compose_runner import coverage
@@ -39,6 +41,30 @@ LGR = logging.getLogger(__name__)
 
 def gen_database_url(branch, database):
     return f"https://github.com/neurostuff/neurostore_database/raw/{branch}/{database}.json.gz"
+
+
+def gen_release_url(store_host, version):
+    """URL for one of neurostore's parquet studyset releases."""
+    host = store_host.rstrip("/")
+    return f"{host}/neurostore-studyset-releases/{version}/download"
+
+
+def _extract_studyset_release(archive, destination):
+    """Unpack a studyset release and return the directory holding its tables.
+
+    The archive carries a single directory named for the release, so the
+    ``studyset.json`` manifest sits one level below the root rather than at it.
+    """
+    with tarfile.open(archive, "r:gz") as tar:
+        tar.extractall(destination, filter="data")
+
+    manifests = sorted(destination.glob("**/studyset.json"))
+    if not manifests:
+        raise ValueError(
+            f"{archive.name} is not a studyset parquet release: it has no "
+            "studyset.json manifest."
+        )
+    return manifests[0].parent
 
 
 def _annotation_column(studyset, column):
@@ -98,6 +124,13 @@ class Runner:
 
     _TARGET_SPACE = "mni152_2mm"
 
+    # Which reference studysets come from neurostore's studyset release API, as
+    # a tarball of parquet tables, rather than from a static NIMADS dump. Only
+    # neurostore's own: a release carries no record of which database a study
+    # came from, so a neurosynth or neuroquery subset cannot be cut out of one.
+    _RELEASE_REFERENCES = frozenset({"neurostore"})
+    _REFERENCE_RELEASE_VERSION = "nightly"
+
     _ENTITY_SNAPSHOT_ID_KEYS = {
         "studyset": ("snapshot_studyset_id",),
         "annotation": ("snapshot_annotation_id",),
@@ -133,12 +166,17 @@ class Runner:
         self.compose_url = compose_host
 
         ref_branch = "main" if environment == "production" else "staging"
-        ref_dbs = ["neurosynth", "neuroquery", "neurostore"]
+        ref_dbs = ["neurosynth", "neuroquery"]
         if environment != "production":
             ref_dbs.append("neurostore_small")
         self.reference_studysets = {
             db: gen_database_url(ref_branch, db) for db in ref_dbs
         }
+        # Served by this environment's own API, so the comparison group is the
+        # database the studyset was selected from as it stands tonight.
+        self.reference_studysets["neurostore"] = gen_release_url(
+            store_host, self._REFERENCE_RELEASE_VERSION
+        )
 
         self._compose_config = neurosynth_compose_sdk.Configuration(host=compose_host)
         self.compose_api = ComposeApi(
@@ -599,46 +637,94 @@ class Runner:
         elif len(conditions) <= 1 and database_studyset:
             # collect user study IDs cheaply before loading the large reference database
             study_ids = set(studyset.study_ids)
-
-            # Download the gzip file
-            response = requests.get(self.reference_studysets[database_studyset])
-
-            try:
-                response.raise_for_status()
-            except requests.exceptions.HTTPError as e:
-                raise requests.exceptions.HTTPError(
-                    f"Could not download reference studyset {database_studyset}."
-                ) from e
-
-            # Wrap the content of the response in a BytesIO object
-            gzip_content = io.BytesIO(response.content)
-
-            # Decompress the gzip content
-            with gzip.GzipFile(fileobj=gzip_content, mode="rb") as gz_file:
-                # Read and decode the JSON data
-                json_data = gz_file.read().decode("utf-8")
-
-                # Load the JSON data into a dictionary
-                reference_studyset_dict = json.loads(json_data)
-
-            # pre-filter at the dict level to exclude user studies before constructing
-            # Studyset, keeping the object small and avoiding expensive materialize calls
-            reference_studyset_dict["studies"] = [
-                s
-                for s in reference_studyset_dict.get("studies", [])
-                if s["id"] not in study_ids
-            ]
-
-            reference_studyset = Studyset(
-                reference_studyset_dict, target=self._TARGET_SPACE
+            reference_studyset = self._load_reference_studyset(
+                database_studyset, study_ids
             )
-            del reference_studyset_dict
 
             second_studyset = (
                 reference_studyset.combine_analyses() if combine else reference_studyset
             )
 
             return first_studyset, second_studyset
+
+    def _load_reference_studyset(self, database_studyset, exclude_study_ids):
+        """The comparison group for a database meta-analysis.
+
+        The user's own studies are excluded from it: they are already the other
+        group, and an analysis cannot be in both.
+        """
+        if database_studyset in self._RELEASE_REFERENCES:
+            return self._load_release_reference(database_studyset, exclude_study_ids)
+        return self._load_dump_reference(database_studyset, exclude_study_ids)
+
+    def _get_reference_studyset(self, database_studyset, **kwargs):
+        """Request a reference studyset, naming it in the error if it is not served."""
+        response = requests.get(self.reference_studysets[database_studyset], **kwargs)
+
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            response.close()
+            raise requests.exceptions.HTTPError(
+                f"Could not download reference studyset {database_studyset}."
+            ) from e
+
+        return response
+
+    def _load_release_reference(self, database_studyset, exclude_study_ids):
+        """Read a reference studyset from a parquet studyset release.
+
+        Streamed to disk rather than held in memory: the archive is tens of
+        megabytes and has to be unpacked to a directory for NiMARE to read it.
+        """
+        with tempfile.TemporaryDirectory() as workdir:
+            archive = Path(workdir) / "release.tar.gz"
+            with self._get_reference_studyset(
+                database_studyset, stream=True
+            ) as response, archive.open("wb") as handle:
+                for chunk in response.iter_content(chunk_size=1024 * 1024):
+                    handle.write(chunk)
+
+            release_dir = _extract_studyset_release(archive, Path(workdir) / "release")
+            # The reference is only ever the comparison group, so nothing reads
+            # its notes: its annotation columns are pure cost here.
+            store = from_parquet(str(release_dir), load_annotations=False)
+
+        # The tables are read eagerly, so the studyset outlives the directory.
+        reference_studyset = Studyset(store, target=self._TARGET_SPACE)
+        # As a list: the ids are matched with ``numpy.isin``, which reads a set
+        # as one opaque object and so quietly excludes nothing.
+        return reference_studyset.exclude_study_ids(list(exclude_study_ids))
+
+    def _load_dump_reference(self, database_studyset, exclude_study_ids):
+        """Read a reference studyset from a gzipped NIMADS dump."""
+        response = self._get_reference_studyset(database_studyset)
+
+        # Wrap the content of the response in a BytesIO object
+        gzip_content = io.BytesIO(response.content)
+
+        # Decompress the gzip content
+        with gzip.GzipFile(fileobj=gzip_content, mode="rb") as gz_file:
+            # Read and decode the JSON data
+            json_data = gz_file.read().decode("utf-8")
+
+            # Load the JSON data into a dictionary
+            reference_studyset_dict = json.loads(json_data)
+
+        # pre-filter at the dict level to exclude user studies before constructing
+        # Studyset, keeping the object small and avoiding expensive materialize calls
+        reference_studyset_dict["studies"] = [
+            s
+            for s in reference_studyset_dict.get("studies", [])
+            if s["id"] not in exclude_study_ids
+        ]
+
+        reference_studyset = Studyset(
+            reference_studyset_dict, target=self._TARGET_SPACE
+        )
+        del reference_studyset_dict
+
+        return reference_studyset
 
     def _is_image_based(self):
         """Whether the specification asks for an image-based meta-analysis."""

--- a/compose_runner/tests/test_reference_studyset.py
+++ b/compose_runner/tests/test_reference_studyset.py
@@ -1,0 +1,208 @@
+"""Tests for the reference studyset a database meta-analysis compares against.
+
+The neurostore reference is served by the studyset release API as a tarball of
+parquet tables, rebuilt nightly; the other databases are static NIMADS dumps
+committed to a GitHub repo. Both have to arrive as a studyset with the user's own
+studies taken out of it.
+"""
+
+import gzip
+import io
+import json
+import tarfile
+
+import pytest
+import requests
+from nimare.nimads import Studyset
+
+from compose_runner.run import Runner, _extract_studyset_release, gen_release_url
+
+_TARGET = "mni152_2mm"
+
+
+def _analysis(analysis_id, x):
+    return {
+        "id": analysis_id,
+        "name": analysis_id,
+        "conditions": [],
+        "weights": [],
+        "points": [
+            {
+                "id": f"p-{analysis_id}",
+                "coordinates": [x, x, x],
+                "space": "MNI",
+                "values": [],
+            }
+        ],
+        "metadata": {},
+        "images": [],
+    }
+
+
+def _reference_dict():
+    """A three-study reference database, one of whose studies is the user's."""
+    return {
+        "id": "reference",
+        "name": "reference",
+        "studies": [
+            {
+                "id": f"s{i}",
+                "name": f"s{i}",
+                "metadata": {},
+                "analyses": [_analysis(f"a{i}", i)],
+            }
+            for i in (1, 2, 3)
+        ],
+    }
+
+
+def _release_archive(tmp_path, source=None):
+    """A studyset release tarball, laid out as the API serves one."""
+    release = tmp_path / "neurostore-studyset-nightly"
+    Studyset(source or _reference_dict(), target=None).to_parquet(release)
+
+    archive = tmp_path / "release.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(release, arcname=release.name)
+    return archive.read_bytes()
+
+
+class _FakeResponse:
+    """Enough of a ``requests`` response for either reference loader."""
+
+    def __init__(self, content, status=200):
+        self.content = content
+        self._status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
+    def raise_for_status(self):
+        if self._status >= 400:
+            raise requests.exceptions.HTTPError(f"{self._status}")
+
+    def iter_content(self, chunk_size=1):
+        for start in range(0, len(self.content), chunk_size):
+            yield self.content[start : start + chunk_size]
+
+    def close(self):
+        self.closed = True
+
+
+def _runner(environment="production"):
+    return Runner(meta_analysis_id="unused", environment=environment)
+
+
+def _serve(monkeypatch, response):
+    """Answer every reference request with ``response``, recording the URL."""
+    requested = []
+
+    def fake_get(url, **kwargs):
+        requested.append((url, kwargs))
+        return response
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    return requested
+
+
+@pytest.mark.parametrize(
+    "environment,expected",
+    [
+        (
+            "production",
+            "https://neurostore.org/api/neurostore-studyset-releases/nightly/download",
+        ),
+        (
+            "staging",
+            "https://staging.neurostore.xyz/api"
+            "/neurostore-studyset-releases/nightly/download",
+        ),
+    ],
+)
+def test_neurostore_reference_comes_from_this_environments_release_api(
+    environment, expected
+):
+    runner = _runner(environment)
+
+    assert runner.reference_studysets["neurostore"] == expected
+
+
+def test_the_other_references_are_still_github_dumps():
+    runner = _runner("production")
+
+    assert runner.reference_studysets["neurosynth"].endswith("/main/neurosynth.json.gz")
+    assert runner.reference_studysets["neuroquery"].endswith("/main/neuroquery.json.gz")
+
+
+def test_gen_release_url_does_not_double_the_separator():
+    assert gen_release_url("https://neurostore.org/api/", "2026-08") == (
+        "https://neurostore.org/api/neurostore-studyset-releases/2026-08/download"
+    )
+
+
+def test_release_reference_loads_and_drops_the_users_studies(tmp_path, monkeypatch):
+    runner = _runner()
+    requested = _serve(monkeypatch, _FakeResponse(_release_archive(tmp_path)))
+
+    reference = runner._load_reference_studyset("neurostore", {"s2"})
+
+    assert sorted(reference.study_ids) == ["s1", "s3"]
+    assert sorted(reference.ids) == ["s1-a1", "s3-a3"]
+    # Streamed rather than buffered whole, and read from the release API.
+    assert requested[0][1]["stream"] is True
+    assert requested[0][0] == runner.reference_studysets["neurostore"]
+
+
+def test_release_reference_is_in_the_target_space(tmp_path, monkeypatch):
+    runner = _runner()
+    _serve(monkeypatch, _FakeResponse(_release_archive(tmp_path)))
+
+    reference = runner._load_reference_studyset("neurostore", set())
+
+    assert set(reference.coordinates["space"]) == {_TARGET}
+
+
+def test_release_reference_survives_the_archive_being_cleaned_up(
+    tmp_path, monkeypatch
+):
+    """The tables are read eagerly, so nothing is left pointing at the temp dir."""
+    runner = _runner()
+    _serve(monkeypatch, _FakeResponse(_release_archive(tmp_path)))
+
+    reference = runner._load_reference_studyset("neurostore", set())
+
+    assert len(reference.coordinates) == 3
+
+
+def test_a_reference_the_api_does_not_serve_is_named_in_the_error(monkeypatch):
+    runner = _runner()
+    _serve(monkeypatch, _FakeResponse(b"", status=404))
+
+    with pytest.raises(requests.exceptions.HTTPError, match="neurostore"):
+        runner._load_reference_studyset("neurostore", set())
+
+
+def test_an_archive_without_a_manifest_is_not_a_release(tmp_path):
+    archive = tmp_path / "not-a-release.tar.gz"
+    stray = tmp_path / "stray.txt"
+    stray.write_text("nothing to load")
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(stray, arcname="stray.txt")
+
+    with pytest.raises(ValueError, match="not a studyset parquet release"):
+        _extract_studyset_release(archive, tmp_path / "out")
+
+
+def test_dump_reference_still_reads_gzipped_nimads(monkeypatch):
+    runner = _runner()
+    payload = gzip.compress(json.dumps(_reference_dict()).encode("utf-8"))
+    requested = _serve(monkeypatch, _FakeResponse(payload))
+
+    reference = runner._load_reference_studyset("neurosynth", {"s1"})
+
+    assert sorted(reference.study_ids) == ["s2", "s3"]
+    assert "stream" not in requested[0][1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,10 @@ dependencies = [
     # IBMA support needs the dependence handling and `groupby` argument, and the
     # runner reads a studyset's annotations off the studyset itself, which the
     # columnar rewrite (NiMARE #1103) introduced. All of it releases as NiMARE
-    # 0.21.0. Replace with `nimare>=0.21.0` once it is on PyPI, which publishing
-    # this package requires anyway: PyPI rejects direct references.
-    "nimare==0.21.0rc3",
+    # 0.21.0. Replace with `nimare[parquet]>=0.21.0` once it is on PyPI, which
+    # publishing this package requires anyway: PyPI rejects direct references.
+    # The `parquet` extra is pyarrow, which reading a studyset release needs.
+    "nimare[parquet]==0.21.0rc3",
     "click",
     "requests",
     "sentry-sdk",


### PR DESCRIPTION
closes #58
A pairwise meta-analysis against the neurostore reference dataset was comparing to `neurostore.json.gz` in the neurostore_database repo, last committed 2023-11-22: 20,826 studies and 42,797 analyses. The release API serves the same database rebuilt nightly -- 32,444 studies and 115,747 analyses today -- as a tarball of parquet tables, from whichever environment the runner is pointed at.

Streamed to a temp directory rather than buffered whole, since the archive has to be unpacked for NiMARE to read it, and loaded without annotations: the reference is only ever the comparison group, so its 900-odd note columns are never read. Loads in ~12 s at 1.5 GB, against ~5 s and 1.3 GB for the dump it replaces.

The exclusion of the user's own studies is passed as a list, not the set it arrives as: `exclude_study_ids` matches with `numpy.isin`, which reads a set as one opaque object and so quietly excludes nothing.

neurosynth and neuroquery still come from the repo. A release records no provenance -- its `source` column is how the base study was identified (semantic_scholar, pubmed), not which database the study came from -- so neither subset can be cut out of one.